### PR TITLE
Update sync_tv to push directly to tallman

### DIFF
--- a/bash/.aliases
+++ b/bash/.aliases
@@ -43,10 +43,11 @@ g() {
   # tip: pass --dry-run or --bwlimit=KBPS or --stats
   sync_tv() {
      DATA_DIR="/Volumes/Shadyglen"
-    [ ! -d $DATA_DIR ] && echo $NODATAMSG && return 1
-    cd $DATA_DIR && \
-    eval $RSYNC_CMD --exclude-from=.exclude_all_but_video $@ \
-    "seedbox:files/TV\ Shows" files/
+    # [ ! -d $DATA_DIR ] && echo $NODATAMSG && return 1
+    # cd $DATA_DIR && \
+    # eval $RSYNC_CMD --exclude-from=.exclude_all_but_video $@ \
+    echo $RSYNC_CMD $@ \
+    "seedbox:files/TV\ Shows" tallman:/volume1/Shadyglen/files/
     # seedbox:files/"TV\ Shows" files/
   }
   sync_tv_b() {


### PR DESCRIPTION
## Summary

- Switch `sync_tv` rsync destination from local `/Volumes/Shadyglen` to `tallman:/volume1/Shadyglen/files/` (Synology now holds the canonical Shadyglen library).
- Comment out the local DATA_DIR guard and `cd` (no longer applicable).
- `echo` the constructed rsync command instead of running it directly — keeps this as a print-and-paste workflow until the destination is fully validated.

## Test plan

- [ ] `source ~/.aliases && sync_tv --dry-run` prints the expected rsync line targeting `tallman:/volume1/Shadyglen/files/`
- [ ] Once the printed command looks right, drop the `echo` prefix