### PR TITLE
Add ~/.local/bin to PATH

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -115,3 +115,4 @@ fi
 
 # Enable bash completion for specific commands
 autoload -U +X bashcompinit && bashcompinit
+export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Summary

- Prepend `$HOME/.local/bin` to `PATH` in `zsh/.zshrc` so user-installed scripts/binaries (pipx, manual installs, etc.) take precedence over system tools.

## Test plan

- [ ] Open a new shell, run `echo $PATH | tr ':' '\n' | head` — `~/.local/bin` should be at or near the front
- [ ] Drop a test script into `~/.local/bin`, confirm `which` finds it