### PR TITLE
Manage ghostty config under stow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For a complete guide on setting up a Mac, see [Dana's Workstation Runlist](https
 * `cd ~/configs`
 * Make sure we have [GNU Stow](https://www.gnu.org/software/stow/)
   * `brew install stow  # or apt or whatever`
-* `stow bash zsh git ruby tmux vim ssh other`
+* `stow bash zsh git ghostty ruby tmux vim ssh other`
 
 
 ## Migrating from setup.sh to GNU Stow

--- a/ghostty/.config/ghostty/config
+++ b/ghostty/.config/ghostty/config
@@ -1,0 +1,51 @@
+# This is the configuration file for Ghostty.
+#
+# This template file has been automatically created at the following
+# path since Ghostty couldn't find any existing config files on your system:
+#
+#   /Users/dmerrick/Library/Application Support/com.mitchellh.ghostty/config
+#
+# The template does not set any default options, since Ghostty ships
+# with sensible defaults for all options. Users should only need to set
+# options that they want to change from the default.
+#
+# Run `ghostty +show-config --default --docs` to view a list of
+# all available config options and their default values.
+#
+# Additionally, each config option is also explained in detail
+# on Ghostty's website, at https://ghostty.org/docs/config.
+#
+# Ghostty can reload the configuration while running by using the menu
+# options or the bound key (default: Command + Shift + comma on macOS and
+# Control + Shift + comma on other platforms). Not all config options can be
+# reloaded while running; some only apply to new windows and others may require
+# a full restart to take effect.
+
+# Config syntax crash course
+# ==========================
+# # The config file consists of simple key-value pairs,
+# # separated by equals signs.
+# font-family = Iosevka
+# window-padding-x = 2
+#
+# # Spacing around the equals sign does not matter.
+# # All of these are identical:
+# key=value
+# key= value
+# key =value
+# key = value
+#
+# # Any line beginning with a # is a comment. It's not possible to put
+# # a comment after a config option, since it would be interpreted as a
+# # part of the value. For example, this will have a value of "#123abc":
+# background = #123abc
+#
+# # Empty values are used to reset config keys to default.
+# key =
+#
+# # Some config options have unique syntaxes for their value,
+# # which is explained in the docs for that config option.
+# # Just for example:
+# resize-overlay-duration = 4s 200ms
+
+copy-on-select = clipboard


### PR DESCRIPTION
## Summary

Move the Ghostty config into a stow package so bootstrapping a new machine is a single `stow` invocation, no manual symlinks needed.

- New layout: `ghostty/.config/ghostty/config` (was: top-level `ghostty` file)
- Add `ghostty` to the stow command in the README install instructions
- `stow ghostty` now creates `~/.config/ghostty/config -> ~/configs/ghostty/.config/ghostty/config`

## Migration on existing machines

```sh
rm ~/.config/ghostty/config   # remove the old hand-rolled symlink
cd ~/configs && stow ghostty
```

## Test plan

- [ ] `cd ~/configs && stow -n -v ghostty` shows the expected new symlink and no conflicts (after removing the old one)
- [ ] After stowing, `readlink ~/.config/ghostty/config` resolves to `~/configs/ghostty/.config/ghostty/config`
- [ ] Ghostty still loads the config (e.g. `copy-on-select = clipboard` still applies)