### PR TITLE
Small cleanups: ignore DS_Store, drop RVM PATH, update email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ old_configs
 vim/.vim/bundle
 vim/.vim/colors
 vim/.vim/black
+.DS_Store

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,6 +1,6 @@
 [user]
   name = Dana Merrick
-	email = dmerrick@ginkgobioworks.com
+	email = danadotlol@gmail.com
 [color]
   ui = auto
 [core]

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -13,9 +13,6 @@ setopt PROMPT_SUBST
 PROMPT='%(?.%F{green}√.%F{red}?%?)%f ${vcs_info_msg_0_} %B%F{240}%1~%f%b %# '
 # PROMPT='${PWD/#$HOME/~} ${vcs_info_msg_0_} > '
 
-# Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
-export PATH="$PATH:$HOME/.rvm/bin"
-
 # Add custom bin directory to PATH
 export PATH="$PATH:$HOME/bin"
 


### PR DESCRIPTION
## Summary

Three independent drift fixes, one commit each:

- `.gitignore`: add `.DS_Store` so future macOS detritus doesn't sneak in
- `zsh/.zshrc`: drop the `$HOME/.rvm/bin` PATH addition — RVM hasn't been on this machine in years
- `git/.gitconfig`: update `user.email` from old `ginkgobioworks.com` address to `danadotlol@gmail.com`

## Test plan

- [ ] `git config user.email` reports `danadotlol@gmail.com`
- [ ] New shell still loads cleanly (`time zsh -i -c exit` is comparable)
- [ ] `git status` in a fresh checkout doesn't show DS_Store as untracked